### PR TITLE
Add Float16, Float32, Float64 and Float128 types

### DIFF
--- a/gccjit_sys/src/lib.rs
+++ b/gccjit_sys/src/lib.rs
@@ -120,6 +120,10 @@ pub enum gcc_jit_types {
     GCC_JIT_TYPE_INT128_T,
 
     GCC_JIT_TYPE_BFLOAT16,
+    GCC_JIT_TYPE_FLOAT16,
+    GCC_JIT_TYPE_FLOAT32,
+    GCC_JIT_TYPE_FLOAT64,
+    GCC_JIT_TYPE_FLOAT128,
 }
 
 #[repr(C)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -1320,6 +1320,10 @@ pub enum CType {
     UInt128t,
     ConstCharPtr,
     BFloat16,
+    Float16,
+    Float32,
+    Float64,
+    Float128,
 }
 
 impl CType {
@@ -1353,6 +1357,10 @@ impl CType {
             UInt128t => GCC_JIT_TYPE_UINT128_T,
             ConstCharPtr => GCC_JIT_TYPE_CONST_CHAR_PTR,
             BFloat16 => GCC_JIT_TYPE_BFLOAT16,
+            Float16 => GCC_JIT_TYPE_FLOAT16,
+            Float32 => GCC_JIT_TYPE_FLOAT32,
+            Float64 => GCC_JIT_TYPE_FLOAT64,
+            Float128 => GCC_JIT_TYPE_FLOAT128,
         }
     }
 }


### PR DESCRIPTION
Requires https://github.com/rust-lang/gcc/pull/47 to be merged and released