### PR TITLE
rename param arr_length->num_values in gcc_jit_context_new_struct_con…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Download and install GCC fork
         run: |
-          curl -LO https://github.com/antoyo/gcc/releases/latest/download/gcc-13.deb
-          sudo dpkg --force-overwrite -i gcc-13.deb
+          curl -LO https://github.com/antoyo/gcc/releases/latest/download/gcc-15.deb
+          sudo dpkg --force-overwrite -i gcc-15.deb
 
       - name: Set env
         run: |

--- a/gccjit_sys/src/lib.rs
+++ b/gccjit_sys/src/lib.rs
@@ -588,7 +588,7 @@ extern {
 
     pub fn gcc_jit_lvalue_set_register_name(lvalue: *mut gcc_jit_lvalue, reg_name: *const c_char);
 
-    pub fn gcc_jit_context_new_struct_constructor(ctxt: *mut gcc_jit_context, loc: *mut gcc_jit_location, typ: *mut gcc_jit_type, arr_length: c_int, fields: *mut *mut gcc_jit_field, values: *mut *mut gcc_jit_rvalue) -> *mut gcc_jit_rvalue;
+    pub fn gcc_jit_context_new_struct_constructor(ctxt: *mut gcc_jit_context, loc: *mut gcc_jit_location, typ: *mut gcc_jit_type, num_values: c_int, fields: *mut *mut gcc_jit_field, values: *mut *mut gcc_jit_rvalue) -> *mut gcc_jit_rvalue;
     pub fn gcc_jit_context_new_union_constructor(ctxt: *mut gcc_jit_context, loc: *mut gcc_jit_location, typ: *mut gcc_jit_type, field: *mut gcc_jit_field, value: *mut gcc_jit_rvalue) -> *mut gcc_jit_rvalue;
     pub fn gcc_jit_context_new_array_constructor(ctxt: *mut gcc_jit_context, loc: *mut gcc_jit_location, typ: *mut gcc_jit_type, arr_length: c_int, values: *mut *mut gcc_jit_rvalue) -> *mut gcc_jit_rvalue;
     pub fn gcc_jit_global_set_initializer_rvalue(global: *mut gcc_jit_lvalue, init_value: *mut gcc_jit_rvalue) -> *mut gcc_jit_lvalue;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub use target_info::TargetInfo;
 
 #[cfg(feature="master")]
 pub fn set_global_personality_function_name(name: &'static [u8]) {
-    debug_assert!(name.ends_with(&[b'\0']), "Expecting a NUL-terminated C string");
+    debug_assert!(name.ends_with(b"\0"), "Expecting a NUL-terminated C string");
     unsafe {
         gccjit_sys::gcc_jit_set_global_personality_function_name(name.as_ptr() as *const _);
     }


### PR DESCRIPTION
I've been using `gcc_jit_context_new_struct_constructor` function that i realized there is small difference between the param name and gccjit's reference. It does not affect any other part of the project so merging is safe.

Reference:

https://gcc.gnu.org/onlinedocs/jit/topics/expressions.html#c.gcc_jit_context_new_struct_constructor